### PR TITLE
Add type for through with a Duplex stream

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,9 +1,9 @@
 [ignore]
-.*\(lib\|test\|builtin-modules\|binary-extensions\|faker\|spdx\).*\.json
 
 [include]
 
 [libs]
 
 [options]
+suppress_comment=\\(.\\|\n\\)*\\$ExpectError
 experimental.strict_type_args=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: node_js
 node_js:
 - 6
 cache: yarn
+script:
+- yarn run eslint
+- yarn run flow
 deploy:
   provider: npm
   email: joe.grund@intel.com

--- a/flow-typed/highland.js
+++ b/flow-typed/highland.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type { Writable, Readable } from 'stream';
+import type { Writable, Readable, Duplex } from 'stream';
 
 declare module highland {
   declare type argsToVoid = (...rest: mixed[]) => void;
@@ -52,6 +52,7 @@ declare module highland {
     through<R>(
       fn: (s: HighlandStream<T>) => HighlandStream<R>
     ): HighlandStream<R>,
+    through<R>(Duplex): HighlandStream<R>,
     zip<R>(ys: HighlandStream<R> | Array<R>): HighlandStream<[T, R]>,
     uniqBy(fn: (T, T) => boolean): HighlandStream<T>,
     pluck<R>(prop: string): HighlandStream<R>,

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "4.1.0",
   "description": "A module to hold highland flow types",
   "scripts": {
+    "flow": "flow",
     "eslint": "eslint ./"
   },
   "pre-commit": [
+    "flow",
     "eslint"
   ],
   "repository": {
@@ -26,6 +28,7 @@
     "eslint-config-prettier": "^1.5.0",
     "eslint-plugin-flowtype": "^2.30.4",
     "eslint-plugin-prettier": "^2.0.1",
+    "flow-bin": "0.45.0",
     "highland": "3.0.0-beta.4",
     "pre-commit": "^1.2.2",
     "prettier": "1.2.2"

--- a/test/typing.js
+++ b/test/typing.js
@@ -4,11 +4,10 @@ import highland from 'highland';
 
 import type { HighlandStreamT } from 'highland';
 
-// should error.
+// $ExpectError
 const s = highland([1, 2, 3]);
 (s: HighlandStreamT<string>);
 
-//should pass.
 const n = highland([1, 2, 3]).onDestroy(() => {});
 (n: HighlandStreamT<number>);
 
@@ -20,34 +19,29 @@ const n2 = n.map(x => x + 's');
 const n3 = n2.filter(x => x.length > 2);
 (n3: HighlandStreamT<string>);
 
-//should error
 const g = highland(push => {
+  // $ExpectError
   push(null, 1);
 });
 (g: HighlandStreamT<string>);
 
-//should pass
 const g2 = highland(push => {
   push(null, 1);
 });
 (g2: HighlandStreamT<number>);
 
-//should pass
 const s3 = highland([[1, 2, 3]]).flatten();
 
 (s3: HighlandStreamT<number>);
 
-//should pass
 const s4 = highland.map(x => x + 1);
 
 (s4: (xs: HighlandStreamT<number>) => HighlandStreamT<number>);
 
-//should pass
 const s5 = highland.filter(x => x != null);
 
 (s5: (xs: HighlandStreamT<number>) => HighlandStreamT<number>);
 
-// Zip
 const zipper1 = highland([[{ name: 'John Doe' }, { name: 'Jane Doe' }]]).zip([
   [{ id: 1 }, { id: 2 }]
 ]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -828,6 +828,10 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
+flow-bin@0.45.0:
+  version "0.45.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.45.0.tgz#009dd0f577a3f665c74ca8be827ae8c2dd8fd6b5"
+
 flow-parser@0.43.0:
   version "0.43.0"
   resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.43.0.tgz#e2b8eb1ac83dd53f7b6b04a7c35b6a52c33479b7"


### PR DESCRIPTION
Fixes #5.

Add a type for through with a Duplex stream.

Also fixup tests and add them + eslint travis check.

Signed-off-by: Joe Grund <grundjoseph@gmail.com>