### PR TITLE
Update parallel type.

### DIFF
--- a/flow-typed/highland.js
+++ b/flow-typed/highland.js
@@ -38,7 +38,7 @@ declare module highland {
     filter(fn: (x: any) => boolean): HighlandStream<T>,
     flatten<R>(): HighlandStream<R>,
     sequence<R>(): HighlandStream<R>,
-    parallel(): HighlandStream<T>,
+    parallel<R>(): HighlandStream<R>,
     flatMap<R>(fn: (x: T) => HighlandStream<R>): HighlandStream<R>,
     group<R>(x: string): HighlandStream<R>,
     consume<R>(

--- a/test/typing.js
+++ b/test/typing.js
@@ -63,3 +63,9 @@ const zipper4 = highland([{ name: 'John Doe' }, { name: 'Jane Doe' }]).zip([
   [{ id: 1 }, { id: 2 }]
 ]);
 (zipper4: HighlandStreamT<[{ name: string }, { id: number }[]]>);
+
+const parallel = highland([
+  highland(['1', '2']),
+  highland(['3', '4'])
+]).parallel(2);
+(parallel: HighlandStreamT<string>);


### PR DESCRIPTION
Fixes #7.

`.parallel` is currently returning `HighlandStreamT`, but it should return `T`. For example:

```
var readFile = _.wrapCallback(fs.readFile);
var filenames = _(['foo.txt', 'bar.txt', 'baz.txt']);

// read from up to 10 files at once
filenames.map(readFile)
   .parallel(3)
   .map((x:HighlandStreamT<Buffer>) => x.toString('utf8'))
```

Should be:

```
var readFile = _.wrapCallback(fs.readFile);
var filenames = _(['foo.txt', 'bar.txt', 'baz.txt']);

// read from up to 10 files at once
filenames.map(readFile)
   .parallel(3)
   .map((x:Buffer) => x.toString('utf8'))
```

Signed-off-by: Will Johnson <william.c.johnson@intel.com>