### PR TITLE
Fix stream imports.

### DIFF
--- a/flow-typed/highland.js
+++ b/flow-typed/highland.js
@@ -1,8 +1,8 @@
 // @flow
 
-import type { Writable, Readable, Duplex } from 'stream';
-
 declare module highland {
+  import type { Writable, Readable, Duplex } from 'stream';
+
   declare type argsToVoid = (...rest: mixed[]) => void;
   declare type nilT = { __nil: true };
   declare type errorWrapT = {

--- a/flow-typed/highland.js
+++ b/flow-typed/highland.js
@@ -1,8 +1,7 @@
 // @flow
+import type stream from 'stream';
 
 declare module highland {
-  import type { Writable, Readable, Duplex } from 'stream';
-
   declare type argsToVoid = (...rest: mixed[]) => void;
   declare type nilT = { __nil: true };
   declare type errorWrapT = {
@@ -44,7 +43,7 @@ declare module highland {
     consume<R>(
       fn: (err: Error, x: T, push: pushFn<R>, next: Function) => void
     ): HighlandStream<R>,
-    pipe(dest: Writable): Writable,
+    pipe(dest: stream.Writable): stream.Writable,
     each(fn: (x: T) => any): HighlandStream<nilT>,
     toArray(fn: (xs: T[]) => any): void,
     errors(fn: (err: Error, push: pushFn<T>) => any): HighlandStream<T>,
@@ -52,7 +51,7 @@ declare module highland {
     through<R>(
       fn: (s: HighlandStream<T>) => HighlandStream<R>
     ): HighlandStream<R>,
-    through<R>(Duplex): HighlandStream<R>,
+    through<R>(stream.Duplex): HighlandStream<R>,
     zip<R>(ys: HighlandStream<R> | Array<R>): HighlandStream<[T, R]>,
     uniqBy(fn: (T, T) => boolean): HighlandStream<T>,
     pluck<R>(prop: string): HighlandStream<R>,
@@ -76,8 +75,8 @@ declare module highland {
     <Type>(xs: Array<Type> | Promise<Type>): HighlandStream<Type>,
     <Type>(name: string, emitter: emitterT): HighlandStream<Type>,
     <Type>(
-      stream: Readable,
-      cb: (Readable, Function) => Function
+      stream: stream.Readable,
+      cb: (stream.Readable, Function) => Function
     ): HighlandStream<Type>,
     map<A, B>(
       fn: Fn1<A, B>,

--- a/test/typing.js
+++ b/test/typing.js
@@ -2,6 +2,8 @@
 
 import highland from 'highland';
 
+import { Readable, Writable, Duplex } from 'stream';
+
 import type { HighlandStreamT } from 'highland';
 
 // $ExpectError
@@ -63,3 +65,12 @@ const zipper4 = highland([{ name: 'John Doe' }, { name: 'Jane Doe' }]).zip([
   [{ id: 1 }, { id: 2 }]
 ]);
 (zipper4: HighlandStreamT<[{ name: string }, { id: number }[]]>);
+
+const readable = new Readable();
+(readable: Readable);
+
+const writable = new Writable();
+(writable: Writable);
+
+const duplex = new Duplex();
+(duplex: Duplex);


### PR DESCRIPTION
Fixes #8.

We are doing:


`import type { Writable, Readable, Duplex } from 'stream';`

outside of the module declaration. This causes these types to be lost. For example, say I add the 
following line in the `.flowconfig` file of a different repo:

```
[libs]
node_modules/@mfl/flow-highland/flow-typed
```

Now, I add the following line in a source file:

`import { Readable, Writable } from 'stream';`

I will now receive the following flow error:'

Named import from module `stream`. This module has no named export called `Readable`.
To avoid this problem we can instead import these types within the module declaration.

Signed-off-by: Will Johnson <william.c.johnson@intel.com>